### PR TITLE
Escapes key-value tuples on records

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -222,7 +222,7 @@ mod tests {
             .args(format_args!("msg"))
             .key_values(&(
                 "challenge \"key\"",
-                r#""challenge":"key",{"nested":not really json}"#,
+                r#""challenge":"value",{"nested":not really json}"#,
             ))
             .level(log::Level::Info)
             .build();
@@ -236,7 +236,7 @@ mod tests {
         // Should be an object with a challenge key and value.
         match value.get("challenge \"key\"") {
             Some(Value::String(string)) => {
-                assert_eq!(string, r#""challenge":"key",{"nested":not really json}"#);
+                assert_eq!(string, r#""challenge":"value",{"nested":not really json}"#);
             }
             _ => panic!("Object with challenge key expected"),
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -230,7 +230,7 @@ mod tests {
         // Output the record and then deserialize to make sure it works and we
         // can locate the challenge string.
         let mut buf = Vec::new();
-        write_as_json(&mut buf, &record)?;
+        write(&mut buf, &record)?;
         let value = serde_json::from_str::<Value>(&std::str::from_utf8(&buf)?)?;
 
         // Should be an object with a challenge key and value.


### PR DESCRIPTION
It was possible to break the JSON with stray quotes in either the key or
value of the record. This commit passes the strings through the
write_json_str so that they are properly escaped. In addition, a test is
added to assert the escaping.