### PR TITLE
Pass `str` into `error!`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,7 +80,7 @@ pub fn panic_hook() {
                         "panicked at '{}'", msg,
                         {
                             thread: thread,
-                            location: format!("{}:{}", location.file(), location.line())
+                            location: format!("{}:{}", location.file(), location.line()).as_str()
                         }
                     );
                 }
@@ -91,7 +91,7 @@ pub fn panic_hook() {
                         "panicked at '{}'", msg,
                         {
                             thread: thread,
-                            location: format!("{}:{}", location.file(), location.line()),
+                            location: format!("{}:{}", location.file(), location.line()).as_str(),
                             backtrace: format!("{:?}", backtrace::Backtrace::new())
                         }
                     );


### PR DESCRIPTION
Recently during an upgrade of `log` it appears that the `ToValue` implementation for `String` was removed. There is still an implementation for `str`.

Use `as_str` to convert argument of `error!` to a string reference.

Example error:
```
error[E0277]: the trait bound `std::string::String: ToValue` is not satisfied
  --> /home/tobin/build/github.com/tcharding/json-env-logger/src/lib.rs:79:21
   |
79 | /                     kv_log_macro::error!(
80 | |                         "panicked at '{}'", msg,
81 | |                         {
82 | |                             thread: thread,
83 | |                             location: format!("{}:{}", location.file(), location.line())
84 | |                         }
85 | |                     );
   | |______________________^ the trait `ToValue` is not implemented for `std::string::String`
   |

```

Fixes: #6