### PR TITLE
Fix typo in method documentation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@ use std::{
 ///
 /// # panics
 ///
-/// Panics of logger has already been configured
+/// Panics if logger has already been configured
 pub fn init() {
     try_init().unwrap()
 }


### PR DESCRIPTION
Sry, I've found a very small typo in the documentation... 