### PR TITLE
Add builder_from_env to use custom env var

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,8 @@ readme = "README.md"
 kv-log-macro = "1.0"
 backtrace = { version = "0.3", optional = true }
 chrono = { version = "0.4", optional = true }
-env_logger = { version = "0.7", default_features = false }
-log = { version = "0.4", features = ["kv_unstable", "std"]  }
+env_logger = { version = "0.9", default_features = false }
+log = { version = "0.4.7", features = ["kv_unstable_std"]  }
 serde_json = "1.0"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,10 @@ env_logger = { version = "0.9", default_features = false }
 log = { version = "0.4.7", features = ["kv_unstable_std"]  }
 serde_json = "1.0"
 
+[dev-dependencies]
+serial_test = "0.9.0"
+lazy_static = "1.4.0"
+
 [features]
 default = []
 iso-timestamps = ["chrono"]


### PR DESCRIPTION
This adds a wrapper to Builder::from_env so a variable other than
RUST_LOG can be used

This also updates the log crate to the latest, where the feature has
been changed to "kv_unstable_std", as well as updates env_logger to 0.9

I added a WriteAdapter struct into the tests to capture log output into variables for testing