### PR TITLE
Use kv_unstable_std as log feature to get crate to compile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "json_env_logger"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["softprops <d.tangren@gmail.com>"]
 edition = "2018"
 description = "A structured JSON logger for Rust"
@@ -19,7 +19,7 @@ kv-log-macro = "1.0"
 backtrace = { version = "0.3", optional = true }
 chrono = { version = "0.4", optional = true }
 env_logger = { version = "0.7", default_features = false }
-log = { version = "0.4", features = ["kv_unstable", "std"]  }
+log = { version = "0.4", features = ["kv_unstable_std"]  }
 serde_json = "1.0"
 
 [features]


### PR DESCRIPTION
Closes #6 